### PR TITLE
Generate phpunit.xml and use config for settings

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -89,7 +89,6 @@ EOT
 
 		// Write XML config.
 		$doc = new DOMDocument( '1.0', 'utf-8' );
-		$doc->formatOutput = true; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 
 		// Create PHPUnit Element.
 		$phpunit = $doc->createElement( 'phpunit' );


### PR DESCRIPTION
We can't rely entirely on relative paths. This update writes the phpunit.xml file dynamically to the vendor folder and lets us use the config to affect the output.