### PR TITLE
Pass option pieces separately

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -157,7 +157,8 @@ EOT
 		// Check for passed config option.
 		$input_options = implode( ' ', $input->getArgument( 'options' ) );
 		if ( ! preg_match( '/(-c|--configuration)\s+/', $input_options ) ) {
-			$options[] = '-c vendor/phpunit.xml';
+			$options[] = '-c';
+			$options[] = 'vendor/phpunit.xml';
 		}
 
 		return $this->run_command( $input, $output, 'vendor/bin/phpunit', $options );


### PR DESCRIPTION
The options array should be split split up into individual tokens to work properly rather than the compound `-c vendor/phpunit.xml` we previously had.

Fixes #6 