### PR TITLE
Fix is_valid_test_path

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -232,6 +232,9 @@ EOT
 	 * @return boolean
 	 */
 	protected function is_valid_test_path( string $path ) : bool {
+		if ( empty( $path ) ) {
+			return false;
+		}
 		$full_path = $this->get_root_dir() . DIRECTORY_SEPARATOR . $path;
 		if ( strpos( $path, '*' ) !== false ) {
 			return ! empty( glob( $full_path ) );


### PR DESCRIPTION
Checks if the path is empty and returns false

Fixes #12 