### PR TITLE
PHPUnit: Add support for excludes

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -92,6 +92,14 @@ EOT
 			$test_paths = [ $maybe_test_path ];
 		}
 
+		// Get excludes from config.
+		$excludes = (array) ( $config['excludes'] ?? [] );
+		$excludes = array_map( function ( $path ) {
+			return trim( $path, DIRECTORY_SEPARATOR );
+		}, $excludes );
+		$excludes = array_filter( $excludes, [ $this, 'is_valid_test_path' ] );
+		$excludes = array_unique( $excludes );
+
 		// Write XML config.
 		$doc = new DOMDocument( '1.0', 'utf-8' );
 
@@ -139,6 +147,11 @@ EOT
 				$variant->setAttribute( 'suffix', '-test.php' );
 				$testsuite->appendChild( $variant );
 			}
+		}
+
+		foreach ( $excludes as $exclude ) {
+			$tag = $doc->createElement( 'exclude', "../{$exclude}/" );
+			$testsuite->appendChild( $tag );
 		}
 
 		// Build the doc.


### PR DESCRIPTION
I really love the zero-configuration for PHPUnit, as well as the possibilities I have when just using `composer.json`. However, one thing I am missing is being able to exclude certain directories that would be included due to wildcard patterns I pass to `directories`.

PHPUnit supports `exclude` tags inside `testsuite`, and so this PR adds support for this in the `extra.altis.dev-tools.phpunit` section in the `composr.json` file.

Usage would be like so:

```json
{
    "phpunit": {
        "directories": [
            "content/plugins/*/tests"
        ],
        "excludes": [
            "content/plugins/some-specific-plugin"
        ]
    }
}
```