### PR TITLE
Add default WPCLI module config

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -264,6 +264,10 @@ EOT
 						'letAdminEmailVerification' => true,
 						'letCron' => true,
 					],
+					'WPCLI' => [
+						'path' => '/usr/src/app',
+						'require' => '/usr/src/app/index.php',
+					],
 					'WPBrowser' => [
 						'url' => '%TEST_SITE_WP_URL%',
 						'adminUsername' => '%TEST_SITE_ADMIN_USERNAME%',


### PR DESCRIPTION
I tested it out and this enables the `$I->cli()` type commands to work in the context of the application, any commands added by plugins / themes / Altis etc.. can be executed. Still needs the individual commands or full WP CLI bundle package adding if folks want to run other commands, alternatively just running `exec( 'wp ...' )` will work out of the box so we could document that.