### PR TITLE
Codeception command enhancements

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -450,7 +450,7 @@ EOL;
 	 */
 	protected function run_command( InputInterface $input, OutputInterface $output, string $command, array $options = [] ) {
 		$use_chassis = $input->getOption( 'chassis' );
-		$cli = $this->getApplication()->find( $use_chassis ? 'chassis' : 'local-server' );
+		$cli = $this->getApplication()->find( $use_chassis ? 'chassis' : 'server' );
 
 		// Add the command, default options and input options together.
 		$options = array_merge(
@@ -610,7 +610,6 @@ EOL;
 		return $return;
 	}
 
-
 	/**
 	 * Run Codeception arbitrary commands.
 	 *
@@ -650,7 +649,7 @@ EOL;
 				],
 			] ), $output );
 		} else {
-			$cli = $this->getApplication()->find( 'local-server' );
+			$cli = $this->getApplication()->find( 'server' );
 
 			$return_val = $cli->run( new ArrayInput( [
 				'subcommand' => 'db',
@@ -689,7 +688,7 @@ EOL;
 				],
 			] ), $output );
 		} else {
-			$cli = $this->getApplication()->find( 'local-server' );
+			$cli = $this->getApplication()->find( 'server' );
 
 			$return_val = $cli->run( new ArrayInput( [
 				'subcommand' => 'db',

--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -562,6 +562,9 @@ EOL;
 		$temp_run_file_path = $this->get_root_dir() . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . '.test-running';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 		file_put_contents( $temp_run_file_path, 'true' );
+		register_shutdown_function( function() use ( $temp_run_file_path ) {
+			unlink( $temp_run_file_path );
+		} );
 
 		// Iterate over the suites.
 		foreach ( $suites as $suite ) {
@@ -577,7 +580,6 @@ EOL;
 				register_shutdown_function( function() use ( $input, $output, $temp_run_file_path ) {
 					$output->write( '<info>Removing test databases..</info>', true, $output::VERBOSITY_NORMAL );
 					$this->delete_test_db( $input, $output );
-					unlink( $temp_run_file_path );
 				} );
 			}
 


### PR DESCRIPTION
Fixes a couple of things I noticed, see what you think:

- Decouple unlinking `.test-running` file from shutdown hook for removing the test db
- Use canonical application name `server` instead of `local-server`
- Only create and register shutdown hooks for db and browser once when iterating over suites