### PR TITLE
Do not break on user warnings in PHPUnit

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -372,6 +372,9 @@ EOT
 			'params' => [
 				'codeception.env',
 			],
+			'settings' => [
+				'error_level' => 'E_ALL & ~E_STRICT & ~E_DEPRECATED & ~E_USER_WARNING',
+			],
 		];
 
 		// Merge config from composer.json.


### PR DESCRIPTION
Currently the default PHPUnit error_reporting level is `E_ALL & ~E_STRICT & ~E_DEPRECATED`. This means PHPUnit will throw an exception on an `E_USER_WARNING` which we regularly use in Altis for adding notices.

These should not halt test execution which is what currently happens.