### PR TITLE
Fix undefined offset when running codecept with no subcommand

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -219,7 +219,7 @@ EOT
 		$run_headless_browser = $input->getOption( 'browser' );
 		$use_chassis = $input->getOption( 'chassis' );
 		$options = $input->getArgument( 'options' );
-		$subsubcommand = $options[0];
+		$subsubcommand = $options[0] ?? null;
 
 		// Working directory for codeception is `vendor`, so need to go up once to resolve relative paths correctly.
 		$tests_folder = '../' . $tests_folder;


### PR DESCRIPTION
It should be ok to run without a subcommand to get the list of available subcommands for instance. This ensures we go to the `codecept_passthru` method if no subcommand is specified.