### PR TITLE
Switch to `seleniarm` for the Selenium images

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -762,16 +762,17 @@ EOL;
 		$output->write( sprintf( '<info>Starting headless "%s" browser container..</info>', $browser ), true, $output::VERBOSITY_NORMAL );
 
 		$available_browsers = [
-			'chrome',
-			'firefox',
-			// 'edge', // TODO Buggy driver, dig deeper.
+			'chromium' => 'chromium',
+			'chrome' => 'chromium',
+			'firefox' => 'firefox',
+			// 'edge' => 'edge', // TODO Buggy driver, dig deeper.
 		];
 
-		if ( ! in_array( $browser, $available_browsers, true ) ) {
+		if ( ! array_key_exists( $browser, $available_browsers ) ) {
 			throw new InvalidArgumentException( sprintf(
 				'Browser "%s" is unavailable, available browsers are: %s.',
 				$browser,
-				implode( ', ', $available_browsers ),
+				implode( ', ', array_keys( $available_browsers ) ),
 			) );
 		}
 
@@ -786,11 +787,11 @@ EOL;
 				'--network=host ' .
 				'--name=%3$s_selenium ' .
 				'--shm-size="2g" ' .
-				'selenium/standalone-%4$s:4.0.0-20211102',
+				'seleniarm/standalone-%4$s:4.0.0-20211213',
 			$columns,
 			$lines,
 			$this->get_project_subdomain(),
-			$browser,
+			$available_browsers[ $browser ],
 		);
 
 		passthru( $base_command, $return_var );


### PR DESCRIPTION
The `selenium/standalone-*` images aren't available for arm64, therefore acceptance tests don't work on Apple M1 machines. I've been using the `seleniarm/standalone-*` images in my plugins instead. They're published by the Selenium maintainers but marked as experimental.