### PR TITLE
Fix syntax error in sprintf call

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -280,7 +280,7 @@ EOT
 								'--skip-email --skip-config && wp altis migrate --url=%2$s',
 							'%TEST_SITE_DB_NAME%',
 							'%TEST_SITE_WP_URL%',
-							'%TEST_SITE_WP_DOMAIN%',
+							'%TEST_SITE_WP_DOMAIN%'
 						),
 						'populate' => true,
 						'cleanup' => false,


### PR DESCRIPTION
Seems PHP8 allows this so it was missed at first.