### PR TITLE
Fix syntax error in `array_merge`.

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -430,7 +430,7 @@ EOL;
 			$input->setArgument( 'options', array_merge(
 				$options,
 				in_array( '--', $options, true ) ? [] : [ '--' ],
-				[ '-c', 'vendor/codeception.yml' ],
+				[ '-c', 'vendor/codeception.yml' ]
 			) );
 		}
 


### PR DESCRIPTION
Seems that wasn't picked up earlier. 

reported error
>PHP Parse error: syntax error, unexpected ')' in /dev-tools-command/inc/command/class-command.php on line 431