### PR TITLE
Fix syntax errors

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -813,7 +813,7 @@ EOL;
 			throw new InvalidArgumentException( sprintf(
 				'Browser "%s" is unavailable, available browsers are: %s.',
 				$browser,
-				implode( ', ', $available_browsers ),
+				implode( ', ', $available_browsers )
 			) );
 		}
 
@@ -832,7 +832,7 @@ EOL;
 			$columns,
 			$lines,
 			$this->get_project_subdomain(),
-			$browser,
+			$browser
 		);
 
 		passthru( $base_command, $return_var );


### PR DESCRIPTION
This PR fixes some syntax errors that have been reported on.

>PHP Parse error: syntax error, unexpected ')' in dev-tools-command/inc/command/class-command.php on line 817