### PR TITLE
Update chromeOptions key to include goog: prefix

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -318,7 +318,7 @@ EOT
 						'capabilities' => [
 							'acceptInsecureCerts' => true,
 							'unexpectedAlertBehaviour' => 'accept',
-							'chromeOptions' => [
+							'goog:chromeOptions' => [
 								'args' => [
 									'--headless',
 									'--disable-gpu',


### PR DESCRIPTION
I found that bootstrapping wasn't working without this change, it appears to be undocumented and may be related to the updated version selenium - 4.1.3 vs 4.0.0 since the seleniarm update. Going to confirm that.