### PR TITLE
Add the php-zip extension to the Codespaces container

### DIFF
--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -8,9 +8,13 @@ FROM mcr.microsoft.com/vscode/devcontainers/php:${PHP_VERSION}
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+# Additional dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get -y install --no-install-recommends libzip-dev \
+	&& pecl install zip \
+	&& echo "extension=zip" >> /usr/local/etc/php/conf.d/zip.ini \
+	&& rm -rf /tmp/pear \
+	&& apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/templates/.devcontainer/Dockerfile
+++ b/templates/.devcontainer/Dockerfile
@@ -11,9 +11,8 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # Additional dependencies
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 	&& apt-get -y install --no-install-recommends libzip-dev \
-	&& pecl install zip \
-	&& echo "extension=zip" >> /usr/local/etc/php/conf.d/zip.ini \
-	&& rm -rf /tmp/pear \
+	&& docker-php-ext-install zip \
+	&& docker-php-source delete \
 	&& apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Optional] Uncomment this line to install global node packages.


### PR DESCRIPTION
WordPress uses the php-zip extension to work with plugins and themes that ship in .zip files. This extension is also required by some Codeception dependencies.

Fixes #42