### PR TITLE
Fix the CodeCeption WPCLI module configuration

### DIFF
--- a/inc/command/class-command.php
+++ b/inc/command/class-command.php
@@ -313,8 +313,8 @@ EOT
 						'letCron' => true,
 					],
 					'WPCLI' => [
-						'path' => '/usr/src/app',
-						'require' => '/usr/src/app/index.php',
+						'path' => '/usr/src/app/wordpress',
+						'url' => '%TEST_SITE_WP_DOMAIN%',
 					],
 					'WPBrowser' => [
 						'url' => '%TEST_SITE_WP_URL%',


### PR DESCRIPTION
The default configuration for this module was causing any commands not on the `@before_wp_load` hook to fail silently when using `$I->cli()` because of the `require` parameter with an incorrect `path` - the path should point to the WP directory itself rather than where the `wp-config.php` is stored.

There is still a caveat that `$I->cli()`will only work with other WP CLI commands installed via composer or that are art of the application itself.

Tested locally with:

```php
<?php

class CLICest
{
    public function tryToTest(AcceptanceTester $I)
    {
        $I->cli( [ 'db', 'query', '\'show tables;\'', '--url=altis-dev.altis.dev' ] );
        var_dump( $I->grabLastShellOutput() );
        $I->cli( [ 'option', 'update', 'test', '1' ] );
        var_dump( $I->grabLastShellOutput() );
        $I->cli( [ 'option', 'get', 'test', '--url=altis-dev.altis.dev' ] );
        var_dump( $I->grabLastShellOutput() );
    }
}
```

The URL parameter is just a useful default to avoid a warning about `DOMAIN_CURRENT_SITE` not being defined, and if provided to the command in `$I->cli()` it will override with the user defined value.