### PR TITLE
Adds another specialised vocabulary word

### DIFF
--- a/templates/docslint/styles/config/vocabularies/Altis/accept.txt
+++ b/templates/docslint/styles/config/vocabularies/Altis/accept.txt
@@ -64,6 +64,7 @@ Photoshop
 PhpStorm
 PHPUnit
 [Pp]ingbacks?
+[Pp]laintext
 [Rr]eindex(ing)?
 Rekognition
 [Ss]anitization


### PR DESCRIPTION
Adds 'Plaintext' (with or without a capital letter) to the list of accepted words in the Altis vocabulary.

Resolves https://github.com/humanmade/altis-cms/issues/676
